### PR TITLE
Stream 392/dbt versioning

### DIFF
--- a/.github/workflows/dbt_run_daily_onchain_scores.yml
+++ b/.github/workflows/dbt_run_daily_onchain_scores.yml
@@ -23,7 +23,7 @@ jobs:
   called_workflow_template:
     uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_run_template.yml@main
     with:
-      dbt_command: dbt run -m "tag:onchain_scores"
+      dbt_command: dbt run -s onchain_scores__avalanche,version:latest
       environment: ${{ github.ref == 'refs/heads/main' && 'workflow_prod' || 'workflow_dev' }}
       warehouse: DBT_CLOUD
     secrets: inherit 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ silver:
 
 onchain_scores:
 	@dbt run \
-		-m tag:onchain_scores \
+		-s onchain_scores__avalanche,version:latest \
 		--profile datascience \
 		--target dev \
 		--profiles-dir ~/.dbt 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -33,6 +33,8 @@ clean-targets: # directories to be removed by `dbt clean`
 # as tables. These settings can be overridden in the individual model files
 # using the `{{ config(...) }}` macro.
 models:
+  post-hook:
+    - "{{ create_latest_version_view() }}"
   livequery_models:
     deploy:
       core:

--- a/macros/create_latest_version_view.sql
+++ b/macros/create_latest_version_view.sql
@@ -1,0 +1,32 @@
+{% macro create_latest_version_view() %}
+
+    -- this hook will run only if the model is versioned, and only if it's the latest version
+    -- otherwise, it's a no-op
+    {% if model.get('version') and model.get('version') == model.get('latest_version') %}
+
+        {% set new_relation = this.incorporate(path={"identifier": model['name']}) %}
+
+        {% set existing_relation = load_relation(new_relation) %}
+
+        {% if existing_relation and not existing_relation.is_view %}
+            {{ drop_relation_if_exists(existing_relation) }}
+        {% endif %}
+        
+        {% set create_view_sql -%}
+            -- this syntax may vary by data platform
+            create or replace view {{ new_relation }}
+              as select * from {{ this }}
+        {%- endset %}
+        
+        {% do log("Creating view " ~ new_relation ~ " pointing to " ~ this, info = true) if execute %}
+        
+        {{ return(create_view_sql) }}
+        
+    {% else %}
+    
+        -- no-op
+        select 1 as id
+    
+    {% endif %}
+
+{% endmacro %}

--- a/macros/custom_naming_macros.sql
+++ b/macros/custom_naming_macros.sql
@@ -11,12 +11,36 @@
         custom_alias_name = none,
         node = none
     ) -%}
-    {% set node_name = node.name %}
-    {% set split_name = node_name.split('__') %}
-    {{ split_name [1] | trim }}
+    
+
+    {%- if custom_alias_name -%}
+
+        {% do log("Creating custom alias for " ~ custom_alias_name, info=true)%}
+
+        {% set node_name = node.name %}
+        {% set split_name = node_name.split('__') %}
+
+        {% do log("Split name: " ~ split_name, info=true)%}
+
+        {{ split_name [1] | trim }}
+
+    {%- elif node.version -%}
+
+        {% do log("Setting node version " ~ node.version ~ " for " ~ node.name, info=true)%}
+
+        {{ return(node.name ~ "_v" ~ (node.version | replace(".", "_"))) }}
+
+    {%- else -%}
+
+        {{ node.name }}
+
+    {%- endif -%}
+
+
 {%- endmacro %}
 
 {% macro generate_tmp_view_name(model_name) -%}
+    {% do log("Generating tmp view model_name: " ~ model_name, info = true) %}
     {% set node_name = model_name.name %}
     {% set split_name = node_name.split('__') %}
     {{ target.database ~ '.' ~ split_name[0] ~ '.' ~ split_name [1] ~ '__dbt_tmp' | trim }}

--- a/models/gold/onchain_scores/onchain_scores__avalanche_v1.sql
+++ b/models/gold/onchain_scores/onchain_scores__avalanche_v1.sql
@@ -4,7 +4,7 @@
     cluster_by = "score_date::date",
     full_refresh = false,
     tags = ['gold', 'onchain_scores', 'avalanche_scores'],
-    version='1'
+    version = 1
 ) }}
 
 {% set current_date_query %}
@@ -360,8 +360,8 @@ total_scores AS (
     SELECT 
         
         {{ dbt_utils.generate_surrogate_key(['user_address', "'avalanche'", "'" ~ current_date_var ~ "'"]) }} AS id,
-        '{{ get_model_version() }}' AS score_version,
         'avalanche' AS blockchain,
+        '{{ model.config.version }}' AS score_version,
         user_address,
         CURRENT_TIMESTAMP AS calculation_time,
         CAST( '{{ current_date_var }}' AS DATE) AS score_date,

--- a/models/gold/onchain_scores/onchain_scores__avalanche_v2.sql
+++ b/models/gold/onchain_scores/onchain_scores__avalanche_v2.sql
@@ -3,7 +3,8 @@
     unique_key = "id",
     cluster_by = "score_date::date",
     full_refresh = false,
-    tags = ['gold', 'onchain_scores', 'avalanche_scores']
+    tags = ['gold', 'onchain_scores', 'avalanche_scores'],
+    version = 2
 ) }}
 
 {% set current_date_query %}
@@ -360,6 +361,7 @@ total_scores AS (
         
         {{ dbt_utils.generate_surrogate_key(['user_address', "'avalanche'", "'" ~ current_date_var ~ "'"]) }} AS id,
         'avalanche' AS blockchain,
+        '{{ model.config.version }}' AS score_version,
         user_address,
         CURRENT_TIMESTAMP AS calculation_time,
         CAST( '{{ current_date_var }}' AS DATE) AS score_date,

--- a/models/gold/onchain_scores/onchain_scores__avalanche_v2.sql
+++ b/models/gold/onchain_scores/onchain_scores__avalanche_v2.sql
@@ -3,8 +3,7 @@
     unique_key = "id",
     cluster_by = "score_date::date",
     full_refresh = false,
-    tags = ['gold', 'onchain_scores', 'avalanche_scores'],
-    version='1'
+    tags = ['gold', 'onchain_scores', 'avalanche_scores']
 ) }}
 
 {% set current_date_query %}
@@ -340,7 +339,7 @@ scores AS (
         user_address,
         (CASE WHEN n_days_active > 2 THEN 1 ELSE 0 END
          + CASE WHEN n_complex_txn > 0 THEN 1 ELSE 0 END
-         + CASE WHEN n_contracts >= 5 THEN 1 ELSE 0 END) AS activity_score,
+         + CASE WHEN n_contracts > 5 THEN 1 ELSE 0 END) AS activity_score,
         (CASE WHEN n_bridge_in > 3 THEN 1 ELSE 0 END
          + CASE WHEN n_cex_withdrawals > 0 THEN 1 ELSE 0 END
          + CASE WHEN net_token_accumulate > 0 THEN 1 ELSE 0 END) AS tokens_score,
@@ -360,7 +359,6 @@ total_scores AS (
     SELECT 
         
         {{ dbt_utils.generate_surrogate_key(['user_address', "'avalanche'", "'" ~ current_date_var ~ "'"]) }} AS id,
-        '{{ get_model_version() }}' AS score_version,
         'avalanche' AS blockchain,
         user_address,
         CURRENT_TIMESTAMP AS calculation_time,


### PR DESCRIPTION
- Add dbt alias in versioning config
  - Adds `create_version_view()` macro to models `post_hook`
    - This functionality will be added to `dbt_core` [in the future](https://github.com/dbt-labs/dbt-core/issues/7442) 
- Updates `generate_alias_name()` macro to support versioning
- Adds `properties.yml` with `model` and `version` config
- Adds `onchain_scores_avalanche_v2` to demostrate model versioning with update to score calculation cut off logic
  - Moves prior score calculation cutoff logic to `onchain__scores_avalanche_v1`
- Adds `score_version` column 
- Update score daily GHA to run latest version of the model 