### PR TITLE
Stream 392/evm models 2

### DIFF
--- a/.github/workflows/dbt_run_daily_onchain_scores.yml
+++ b/.github/workflows/dbt_run_daily_onchain_scores.yml
@@ -43,3 +43,19 @@ jobs:
       environment: ${{ github.ref == 'refs/heads/main' && 'workflow_prod' || 'workflow_dev' }}
       warehouse: DBT_CLOUD
     secrets: inherit
+  
+  polygon_scores:
+    uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_run_template.yml@main
+    with:
+      dbt_command: dbt run -s onchain_scores__polygon,version:latest
+      environment: ${{ github.ref == 'refs/heads/main' && 'workflow_prod' || 'workflow_dev' }}
+      warehouse: DBT_CLOUD
+    secrets: inherit
+  
+  optimism_scores:
+      uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_run_template.yml@main
+      with:
+        dbt_command: dbt run -s onchain_scores__optimism,version:latest
+        environment: ${{ github.ref == 'refs/heads/main' && 'workflow_prod' || 'workflow_dev' }}
+        warehouse: DBT_CLOUD
+      secrets: inherit

--- a/.github/workflows/dbt_run_daily_onchain_scores.yml
+++ b/.github/workflows/dbt_run_daily_onchain_scores.yml
@@ -20,10 +20,26 @@ env:
   SCHEMA: "${{ vars.SCHEMA }}"
 
 jobs:
-  called_workflow_template:
+  avalanche_scores:
     uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_run_template.yml@main
     with:
-      dbt_command: dbt run -m "tag:onchain_scores"
+      dbt_command: dbt run -s onchain_scores__avalanche,version:latest
       environment: ${{ github.ref == 'refs/heads/main' && 'workflow_prod' || 'workflow_dev' }}
       warehouse: DBT_CLOUD
     secrets: inherit 
+
+  ethereum_scores:
+    uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_run_template.yml@main
+    with:
+      dbt_command: dbt run -s onchain_scores__ethereum,version:latest
+      environment: ${{ github.ref == 'refs/heads/main' && 'workflow_prod' || 'workflow_dev' }}
+      warehouse: DBT_CLOUD
+    secrets: inherit 
+  
+  base_scores:
+    uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_run_template.yml@main
+    with:
+      dbt_command: dbt run -s onchain_scores__base,version:latest
+      environment: ${{ github.ref == 'refs/heads/main' && 'workflow_prod' || 'workflow_dev' }}
+      warehouse: DBT_CLOUD
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ silver:
 
 onchain_scores:
 	@dbt run \
-		-m tag:onchain_scores \
+		-m tag:onchain_scoress \
 		--profile datascience \
 		--target dev \
 		--profiles-dir ~/.dbt 

--- a/models/gold/onchain_scores/onchain_scores__base_v1.sql
+++ b/models/gold/onchain_scores/onchain_scores__base_v1.sql
@@ -363,6 +363,14 @@ total_scores AS (
         nfts_score,
         gov_score
     FROM scores
+    {% if is_incremental() %}        
+        WHERE 
+        {% if current_date_var == modules.datetime.datetime.utcnow().date() %}
+            score_date > (SELECT MAX(score_date) FROM {{ this }})
+        {% else %}
+            score_date = CAST('{{ current_date_var }}' AS DATE)
+        {% endif %}
+    {% endif %}
 )
 
 SELECT * FROM total_scores

--- a/models/gold/onchain_scores/onchain_scores__base_v1.sql
+++ b/models/gold/onchain_scores/onchain_scores__base_v1.sql
@@ -1,0 +1,368 @@
+{{ config (
+    materialized = "incremental",
+    unique_key = "id",
+    cluster_by = "score_date::date",
+    full_refresh = false,
+    tags = ['gold','onchain_scores'],
+    version='1'
+) }}
+
+{% set current_date_query %}
+  SELECT date(sysdate()) as current_date
+{% endset %}
+
+{% set results = run_query(current_date_query) %}
+
+{% if execute %}
+  {% set current_date_var = var('current_date_var', results.columns[0].values()[0]) %}
+{% endif %}
+
+-- set aside centralized exchange addresses for two later cte's
+WITH cex_addresses AS (
+    SELECT ADDRESS, LABEL_TYPE, project_name AS label
+    FROM {{ source('base_gold_core','dim_labels') }}
+    WHERE LABEL_TYPE = 'cex'
+),
+
+-- the 3 activity metrics
+activity AS (
+    SELECT
+        from_address AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(DISTINCT CASE WHEN input_data != '0x' THEN to_address END) AS n_contracts,
+        sum(CASE WHEN input_data != '0x' THEN 1 ELSE 0 END) AS n_complex_txn
+    FROM {{ source('base_gold_core','fact_transactions') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    GROUP BY from_address, activity_day
+),
+
+-- count transactions from bridges daily
+from_bridge_daily AS (
+    SELECT 
+        receiver AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_bridge_in,
+        COUNT(DISTINCT platform) AS n_contracts
+    FROM {{ source('base_gold_defi','ez_bridge_activity') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND receiver NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND receiver NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    GROUP BY receiver, activity_day
+),
+-- tx from bridge
+from_bridge AS (
+SELECT
+user_address,
+sum(n_bridge_in) AS n_bridge_in
+FROM
+from_bridge_daily
+GROUP BY 
+user_address
+),
+
+-- count withdrawals from centralized exchanges daily
+from_cex_daily AS (
+    SELECT 
+        to_address AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_cex_withdrawals
+    FROM {{ source('base_gold_core','ez_native_transfers') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address IN (SELECT ADDRESS FROM cex_addresses)
+    AND to_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    GROUP BY to_address, activity_day
+    UNION
+    SELECT 
+        TO_ADDRESS AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_cex_withdrawals
+    FROM {{ source('base_gold_core','ez_token_transfers') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND FROM_ADDRESS IN (SELECT ADDRESS FROM cex_addresses)
+    AND to_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    GROUP BY TO_ADDRESS, activity_day
+),
+-- total cex
+from_cex AS (
+SELECT
+user_address,
+sum(n_cex_withdrawals) AS n_cex_withdrawals
+FROM
+from_cex_daily
+GROUP BY 
+user_address
+),
+-- count days across the three sources
+combined_days AS (
+    SELECT user_address, activity_day FROM activity
+    UNION
+    SELECT user_address, activity_day FROM from_bridge_daily
+    UNION
+    SELECT user_address, activity_day FROM from_cex_daily
+),
+-- count days across the 3 sources
+user_activity_summary AS (
+    SELECT 
+        user_address,
+        COUNT(DISTINCT activity_day) AS n_days_active
+    FROM combined_days
+    GROUP BY user_address
+),
+-- count txn across the 3 sources
+complex_transactions_and_contracts AS (
+    SELECT 
+        user_address,
+        SUM(n_complex_txn) AS n_complex_txn,
+        SUM(n_contracts) AS n_contracts
+    FROM (
+        SELECT user_address, n_complex_txn, n_contracts FROM activity
+        UNION ALL
+        SELECT user_address, n_bridge_in AS n_complex_txn, n_contracts FROM from_bridge_daily
+        UNION ALL
+        SELECT user_address, 0 AS n_complex_txn, 0 AS n_contracts FROM from_cex_daily
+    ) AS sub
+    GROUP BY user_address
+),
+
+-- net token accumulate
+xfer_in AS (
+    SELECT TO_ADDRESS AS user_address, 
+        COUNT(*) AS n_xfer_in
+    FROM {{ source('base_gold_core','ez_token_transfers') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND to_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    GROUP BY TO_ADDRESS
+), 
+
+xfer_out AS (
+    SELECT FROM_ADDRESS AS user_address,
+        COUNT(*) AS n_xfer_out
+    FROM {{ source('base_gold_core','ez_token_transfers') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    GROUP BY FROM_ADDRESS
+),
+
+net_token_accumulate AS (
+    SELECT
+        a.user_address,
+        COALESCE((a.n_xfer_in) / (a.n_xfer_in + b.n_xfer_out), 0) AS net_token_accumulate
+    FROM xfer_in a
+    FULL OUTER JOIN xfer_out b ON a.user_address = b.user_address
+),
+-- nfts
+nft_buys AS (
+    SELECT 
+        buyer_address AS user_address, 
+        COUNT(distinct(NFT_ADDRESS)) AS n_nft_collections,
+        COUNT(*) AS n_nft_trades
+    FROM {{ source('base_gold_nft','ez_nft_sales') }} 
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND buyer_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND buyer_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    GROUP BY buyer_address
+),
+
+rawmints as (
+select
+*,
+case when topics[0] = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62' then 'erc-1155'
+     when (topics[0] = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' 
+       and topics[3] IS NOT NULL) then 'erc-721'
+     else 'erc-20' end as token_standard
+from {{ source('base_gold_core','ez_decoded_event_logs') }} 
+where topics[0] in (
+  '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+  '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
+)
+AND 
+block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+AND decoded_log:from = '0x0000000000000000000000000000000000000000'
+having token_standard IN ('erc-721','erc-1155')
+),
+
+nft_mints AS (
+select 
+decoded_log:to :: string as user_address,
+count(distinct (tx_hash) ) as n_nft_mints
+FROM rawmints
+WHERE
+decoded_log:to NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+AND 
+decoded_log:to NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+group by user_address
+),
+-- governance (just liquid staking on base)
+gov_mints AS (
+    SELECT
+        to_address AS user_address,
+        COUNT(distinct(contract_address)) AS n_validators,
+        COUNT(tx_hash) AS n_stake_tx
+    FROM {{ source('base_gold_core','ez_token_transfers') }}
+    WHERE 
+        contract_address IN (lower('0xB6fe221Fe9EeF5aBa221c348bA20A1Bf5e73624c'),
+                     lower('0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22'),
+                     lower('0xcf3D55c10DB69f28fD1A75Bd73f3D8A2d9c595ad'),
+                     lower('0xD4a0e0b9149BCee3C920d2E00b5dE09138fd8bb7'))
+    AND BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND to_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND from_address = '0x0000000000000000000000000000000000000000'
+    GROUP BY to_address
+),
+
+gov_restakes AS (
+    SELECT 
+        origin_from_address AS user_address,
+        COUNT(tx_hash) AS n_restakes
+    FROM {{ source('base_gold_core','ez_decoded_event_logs') }}
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND contract_address IN (lower('0xB6fe221Fe9EeF5aBa221c348bA20A1Bf5e73624c'),
+                     lower('0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22'),
+                     lower('0xcf3D55c10DB69f28fD1A75Bd73f3D8A2d9c595ad'),
+                     lower('0xD4a0e0b9149BCee3C920d2E00b5dE09138fd8bb7'))
+    AND event_name IN ('Deposit', 'Submitted', 'DepositedFromStaking')
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    GROUP BY origin_from_address
+),
+-- defi
+swaps_in AS (
+    SELECT 
+        origin_from_address AS user_address, 
+        COUNT(*) AS n_swap_tx
+    FROM {{ source('base_gold_defi','ez_dex_swaps') }} 
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    GROUP BY origin_from_address
+),
+
+lp_adds AS (
+    SELECT 
+        FROM_ADDRESS AS USER_ADDRESS, 
+        COUNT(*) AS n_lp_adds
+    FROM {{ source('base_gold_core','ez_token_transfers') }}
+    WHERE TO_ADDRESS IN (SELECT contract_address FROM {{ source('base_gold_defi','ez_dex_swaps') }} WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90)
+    AND TX_HASH NOT IN (SELECT TX_HASH FROM {{ source('base_gold_defi','ez_dex_swaps') }} WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90)
+    AND FROM_ADDRESS NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    AND FROM_ADDRESS NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    GROUP BY FROM_ADDRESS
+),
+-- list of lp and swap transactions to exclude from other defi below
+lps_swaps AS (
+SELECT 
+tx_hash
+FROM
+{{ source('base_gold_core','ez_token_transfers') }}
+WHERE
+to_address IN (SELECT pool_address FROM base.defi.dim_dex_liquidity_pools)
+AND
+block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+GROUP BY tx_hash
+),
+-- other defi is a broad category
+other_defi AS (
+    SELECT
+        origin_from_address AS user_address,
+        COUNT(distinct(tx_hash)) AS n_other_defi
+    FROM {{ source('base_gold_core','ez_decoded_event_logs') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND contract_address NOT IN (lower('0xB6fe221Fe9EeF5aBa221c348bA20A1Bf5e73624c'),
+                     lower('0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22'),
+                     lower('0xcf3D55c10DB69f28fD1A75Bd73f3D8A2d9c595ad'),
+                     lower('0xD4a0e0b9149BCee3C920d2E00b5dE09138fd8bb7'))
+
+    AND tx_hash NOT IN (SELECT tx_hash FROM lps_swaps)
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_contracts') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('base_gold_core','dim_labels') }})
+    AND (
+        lower(event_name) LIKE '%claim%' OR
+        lower(event_name) LIKE '%deposit%' OR
+        lower(event_name) LIKE '%borrow%' OR
+        lower(event_name) LIKE '%lend%' OR
+        lower(event_name) LIKE '%supply%' OR
+        lower(event_name) LIKE '%liquid%' OR
+        lower(event_name) LIKE '%fees%' OR
+        lower(event_name) LIKE '%repay%'
+    )
+    GROUP BY origin_from_address
+),
+-- put it all together!
+final_output AS (
+    SELECT 
+        a.user_address,
+        COALESCE(aa.n_days_active, 0) AS n_days_active,
+        COALESCE(a.n_complex_txn, 0) AS n_complex_txn,
+        COALESCE(a.n_contracts, 0) AS n_contracts,
+        COALESCE(b.n_bridge_in, 0) AS n_bridge_in,
+        COALESCE(c.n_cex_withdrawals, 0) AS n_cex_withdrawals,
+        COALESCE(d.net_token_accumulate, 0) AS net_token_accumulate,
+        COALESCE(e.n_swap_tx, 0) AS n_swap_tx,
+        COALESCE(f.n_other_defi, 0) AS n_other_defi,
+        COALESCE(g.n_lp_adds, 0) AS n_lp_adds,
+        COALESCE(h.n_nft_trades, 0) AS n_nft_trades,
+        COALESCE(h.n_nft_collections, 0) AS n_nft_collections,
+        COALESCE(i.n_nft_mints, 0) AS n_nft_mints,
+        COALESCE(j.n_stake_tx, 0) AS n_stake_tx,
+        COALESCE(j.n_validators, 0) AS n_validators,
+        COALESCE(k.n_restakes, 0) AS n_restakes
+    FROM complex_transactions_and_contracts a
+    LEFT JOIN user_activity_summary aa ON a.user_address = aa.user_address
+    LEFT JOIN from_bridge b ON a.user_address = b.user_address
+    LEFT JOIN from_cex c ON a.user_address = c.user_address
+    LEFT JOIN net_token_accumulate d ON a.user_address = d.user_address
+    LEFT JOIN swaps_in e ON a.user_address = e.user_address
+    LEFT JOIN other_defi f ON a.user_address = f.user_address
+    LEFT JOIN lp_adds g ON a.user_address = g.user_address
+    LEFT JOIN nft_buys h ON a.user_address = h.user_address
+    LEFT JOIN nft_mints i ON a.user_address = i.user_address
+    LEFT JOIN gov_mints j ON a.user_address = j.user_address
+    LEFT JOIN gov_restakes k ON a.user_address = k.user_address
+),
+
+scores AS (
+    SELECT
+        user_address,
+        (CASE WHEN n_days_active > 8 THEN 1 ELSE 0 END
+         + CASE WHEN n_complex_txn > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_contracts > 3 THEN 1 ELSE 0 END) AS activity_score,
+        (CASE WHEN n_bridge_in > 4 THEN 1 ELSE 0 END
+         + CASE WHEN n_cex_withdrawals > 7 THEN 1 ELSE 0 END
+         + CASE WHEN net_token_accumulate > 0 THEN 1 ELSE 0 END) AS tokens_score,
+        (CASE WHEN n_other_defi > 7 THEN 1 ELSE 0 END
+         + CASE WHEN n_swap_tx > 8 THEN 1 ELSE 0 END
+         + CASE WHEN n_lp_adds > 5 THEN 1 ELSE 0 END) AS defi_score,
+        (CASE WHEN n_nft_mints > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_nft_collections > 2 THEN 1 ELSE 0 END
+         + CASE WHEN n_nft_trades > 7 THEN 1 ELSE 0 END) AS nfts_score,
+        (CASE WHEN n_stake_tx > 4 THEN 1 ELSE 0 END
+         + CASE WHEN n_validators > 2 THEN 1 ELSE 0 END
+         + CASE WHEN n_restakes > 0 THEN 1 ELSE 0 END) AS gov_score
+    FROM final_output
+),
+
+total_scores AS (
+    SELECT 
+        {{ dbt_utils.generate_surrogate_key(['user_address', "'base'", "'" ~ current_date_var ~ "'"]) }} AS id,        
+        'base' AS blockchain,
+        '{{ model.config.version }}' AS score_version,
+        user_address,
+        CURRENT_TIMESTAMP AS calculation_time,
+        CAST( '{{ current_date_var }}' AS DATE) AS score_date,
+        activity_score + tokens_score + defi_score + nfts_score + gov_score AS total_score,
+        activity_score,
+        tokens_score,
+        defi_score,
+        nfts_score,
+        gov_score
+    FROM scores
+)
+
+SELECT * FROM total_scores

--- a/models/gold/onchain_scores/onchain_scores__ethereum_v1.sql
+++ b/models/gold/onchain_scores/onchain_scores__ethereum_v1.sql
@@ -1,0 +1,359 @@
+{{ config (
+    materialized = "incremental",
+    unique_key = "id",
+    cluster_by = "score_date::date",
+    full_refresh = false,
+    tags = ['gold','onchain_scores'],
+    version = 1
+) }}
+
+{% set current_date_query %}
+  SELECT date(sysdate()) as current_date
+{% endset %}
+
+{% set results = run_query(current_date_query) %}
+
+{% if execute %}
+  {% set current_date_var = var('current_date_var', results.columns[0].values()[0]) %}
+{% endif %}
+
+-- set aside centralized exchange addresses for two later cte's
+WITH cex_addresses AS (
+    SELECT ADDRESS, LABEL_TYPE, label AS label
+    FROM {{ source('ethereum_gold_core', 'dim_labels') }}
+    WHERE LABEL_TYPE = 'cex'
+),
+
+-- the 3 activity metrics
+activity AS (
+    SELECT
+        from_address AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(DISTINCT CASE WHEN input_data != '0x' THEN to_address END) AS n_contracts,
+        sum(CASE WHEN input_data != '0x' THEN 1 ELSE 0 END) AS n_complex_txn
+    FROM {{ source('ethereum_gold_core', 'fact_transactions') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    GROUP BY from_address, activity_day
+),
+
+-- count transactions from bridges daily
+from_bridge_daily AS (
+    SELECT 
+        receiver AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_bridge_in,
+        COUNT(DISTINCT platform) AS n_contracts
+    FROM {{ source('ethereum_gold_defi','ez_bridge_activity') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND receiver NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND receiver NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    GROUP BY receiver, activity_day
+),
+-- tx from bridge
+from_bridge AS (
+    SELECT
+        user_address,
+        sum(n_bridge_in) AS n_bridge_in
+    FROM
+        from_bridge_daily
+    GROUP BY 
+        user_address
+),
+
+-- count withdrawals from centralized exchanges daily
+from_cex_daily AS (
+    SELECT 
+        to_address AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_cex_withdrawals
+    FROM {{ source('ethereum_gold_core', 'ez_native_transfers') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address IN (SELECT ADDRESS FROM cex_addresses)
+    AND to_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    GROUP BY to_address, activity_day
+    UNION
+    SELECT 
+        TO_ADDRESS AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_cex_withdrawals
+    FROM {{ source('ethereum_gold_core','ez_token_transfers')}} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND FROM_ADDRESS IN (SELECT ADDRESS FROM cex_addresses)
+    AND to_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    GROUP BY TO_ADDRESS, activity_day
+),
+-- total cex
+from_cex AS (
+SELECT
+user_address,
+sum(n_cex_withdrawals) AS n_cex_withdrawals
+FROM
+from_cex_daily
+GROUP BY 
+user_address
+),
+-- count days across the three sources
+combined_days AS (
+    SELECT user_address, activity_day FROM activity
+    UNION
+    SELECT user_address, activity_day FROM from_bridge_daily
+    UNION
+    SELECT user_address, activity_day FROM from_cex_daily
+),
+-- count days across the 3 sources
+user_activity_summary AS (
+    SELECT 
+        user_address,
+        COUNT(DISTINCT activity_day) AS n_days_active
+    FROM combined_days
+    GROUP BY user_address
+),
+-- count txn across the 3 sources
+complex_transactions_and_contracts AS (
+    SELECT 
+        user_address,
+        SUM(n_complex_txn) AS n_complex_txn,
+        SUM(n_contracts) AS n_contracts
+    FROM (
+        SELECT user_address, n_complex_txn, n_contracts FROM activity
+        UNION ALL
+        SELECT user_address, n_bridge_in AS n_complex_txn, n_contracts FROM from_bridge_daily
+        UNION ALL
+        SELECT user_address, 0 AS n_complex_txn, 0 AS n_contracts FROM from_cex_daily
+    ) AS sub
+    GROUP BY user_address
+),
+
+-- net token accumulate
+xfer_in AS (
+    SELECT TO_ADDRESS AS user_address, 
+        COUNT(*) AS n_xfer_in
+    FROM {{ source('ethereum_gold_core','ez_token_transfers')}}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND to_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    GROUP BY TO_ADDRESS
+), 
+
+xfer_out AS (
+    SELECT FROM_ADDRESS AS user_address,
+        COUNT(*) AS n_xfer_out
+    FROM {{ source('ethereum_gold_core','ez_token_transfers')}}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    GROUP BY FROM_ADDRESS
+),
+
+net_token_accumulate AS (
+    SELECT
+        a.user_address,
+        COALESCE((a.n_xfer_in) / (a.n_xfer_in + b.n_xfer_out), 0) AS net_token_accumulate
+    FROM xfer_in a
+    FULL OUTER JOIN xfer_out b ON a.user_address = b.user_address
+),
+-- nfts
+nft_buys AS (
+    SELECT 
+        buyer_address AS user_address, 
+        COUNT(distinct(NFT_ADDRESS)) AS n_nft_collections,
+        COUNT(*) AS n_nft_trades
+    FROM {{ source('ethereum_gold_nft','ez_nft_sales') }} 
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND buyer_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND buyer_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    GROUP BY buyer_address
+),
+
+rawmints as (
+select
+*,
+case when topics[0] = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62' then 'erc-1155'
+     when (topics[0] = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' 
+       and topics[3] IS NOT NULL) then 'erc-721'
+     else 'erc-20' end as token_standard
+from {{ source('ethereum_gold_core','ez_decoded_event_logs') }} 
+where topics[0] in (
+  '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+  '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
+)
+AND 
+block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+AND decoded_log:from = '0x0000000000000000000000000000000000000000'
+having token_standard IN ('erc-721','erc-1155')
+),
+
+nft_mints AS (
+select 
+decoded_log:to :: string as user_address,
+count(distinct (tx_hash) ) as n_nft_mints
+FROM rawmints
+WHERE
+decoded_log:to NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+AND 
+decoded_log:to NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+group by user_address
+),
+-- governance (just liquid staking on ethereum)
+gov_mints AS (
+    SELECT
+        to_address AS user_address,
+        COUNT(distinct(contract_address)) AS n_validators,
+        COUNT(tx_hash) AS n_stake_tx
+    FROM {{ source('ethereum_gold_core','ez_token_transfers')}}
+    WHERE 
+        contract_address IN (select distinct lower(token_address) from ethereum.defi.ez_liquid_staking_deposits)
+    AND BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND to_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND from_address = '0x0000000000000000000000000000000000000000'
+    GROUP BY to_address
+),
+
+gov_restakes AS (
+    SELECT 
+        origin_from_address AS user_address,
+        COUNT(tx_hash) AS n_restakes
+    FROM {{ source('ethereum_gold_core','ez_decoded_event_logs') }}
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND contract_address IN (select distinct lower(token_address) from ethereum.defi.ez_liquid_staking_deposits)
+    AND event_name IN ('Deposit', 'Submitted', 'DepositedFromStaking')
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    GROUP BY origin_from_address
+),
+-- defi
+swaps_in AS (
+    SELECT 
+        origin_from_address AS user_address, 
+        COUNT(*) AS n_swap_tx
+    FROM {{ source('ethereum_gold_defi','ez_dex_swaps')}}
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    GROUP BY origin_from_address
+),
+
+lp_adds AS (
+    SELECT 
+        FROM_ADDRESS AS USER_ADDRESS, 
+        COUNT(*) AS n_lp_adds
+    FROM {{ source('ethereum_gold_core','ez_token_transfers')}}
+    WHERE TO_ADDRESS IN (SELECT contract_address FROM {{ source('ethereum_gold_defi','ez_dex_swaps')}} WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90)
+    AND TX_HASH NOT IN (SELECT TX_HASH FROM {{ source('ethereum_gold_defi','ez_dex_swaps')}} WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90)
+    AND FROM_ADDRESS NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    AND FROM_ADDRESS NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    GROUP BY FROM_ADDRESS
+),
+-- list of lp and swap transactions to exclude from other defi below
+lps_swaps AS (
+SELECT 
+tx_hash
+FROM
+{{ source('ethereum_gold_core','ez_token_transfers')}}
+WHERE
+to_address IN (SELECT pool_address FROM ethereum.defi.dim_dex_liquidity_pools)
+AND
+block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+GROUP BY tx_hash
+),
+-- other defi is a broad category
+other_defi AS (
+    SELECT
+        origin_from_address AS user_address,
+        COUNT(distinct(tx_hash)) AS n_other_defi
+    FROM {{ source('ethereum_gold_core','ez_decoded_event_logs') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND contract_address NOT IN (select distinct lower(token_address) from ethereum.defi.ez_liquid_staking_deposits)
+
+    AND tx_hash NOT IN (SELECT tx_hash FROM lps_swaps)
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_contracts') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('ethereum_gold_core', 'dim_labels') }})
+    AND (
+        lower(event_name) LIKE '%claim%' OR
+        lower(event_name) LIKE '%deposit%' OR
+        lower(event_name) LIKE '%borrow%' OR
+        lower(event_name) LIKE '%lend%' OR
+        lower(event_name) LIKE '%supply%' OR
+        lower(event_name) LIKE '%liquid%' OR
+        lower(event_name) LIKE '%fees%' OR
+        lower(event_name) LIKE '%repay%'
+    )
+    GROUP BY origin_from_address
+),
+-- put it all together!
+final_output AS (
+    SELECT 
+        a.user_address,
+        COALESCE(aa.n_days_active, 0) AS n_days_active,
+        COALESCE(a.n_complex_txn, 0) AS n_complex_txn,
+        COALESCE(a.n_contracts, 0) AS n_contracts,
+        COALESCE(b.n_bridge_in, 0) AS n_bridge_in,
+        COALESCE(c.n_cex_withdrawals, 0) AS n_cex_withdrawals,
+        COALESCE(d.net_token_accumulate, 0) AS net_token_accumulate,
+        COALESCE(e.n_swap_tx, 0) AS n_swap_tx,
+        COALESCE(f.n_other_defi, 0) AS n_other_defi,
+        COALESCE(g.n_lp_adds, 0) AS n_lp_adds,
+        COALESCE(h.n_nft_trades, 0) AS n_nft_trades,
+        COALESCE(h.n_nft_collections, 0) AS n_nft_collections,
+        COALESCE(i.n_nft_mints, 0) AS n_nft_mints,
+        COALESCE(j.n_stake_tx, 0) AS n_stake_tx,
+        COALESCE(j.n_validators, 0) AS n_validators,
+        COALESCE(k.n_restakes, 0) AS n_restakes
+    FROM complex_transactions_and_contracts a
+    LEFT JOIN user_activity_summary aa ON a.user_address = aa.user_address
+    LEFT JOIN from_bridge b ON a.user_address = b.user_address
+    LEFT JOIN from_cex c ON a.user_address = c.user_address
+    LEFT JOIN net_token_accumulate d ON a.user_address = d.user_address
+    LEFT JOIN swaps_in e ON a.user_address = e.user_address
+    LEFT JOIN other_defi f ON a.user_address = f.user_address
+    LEFT JOIN lp_adds g ON a.user_address = g.user_address
+    LEFT JOIN nft_buys h ON a.user_address = h.user_address
+    LEFT JOIN nft_mints i ON a.user_address = i.user_address
+    LEFT JOIN gov_mints j ON a.user_address = j.user_address
+    LEFT JOIN gov_restakes k ON a.user_address = k.user_address
+),
+
+scores AS (
+    SELECT
+        user_address,
+        (CASE WHEN n_days_active > 6 THEN 1 ELSE 0 END
+         + CASE WHEN n_complex_txn > 4 THEN 1 ELSE 0 END
+         + CASE WHEN n_contracts > 0 THEN 1 ELSE 0 END) AS activity_score,
+        (CASE WHEN n_bridge_in > 2 THEN 1 ELSE 0 END
+         + CASE WHEN n_cex_withdrawals > 1 THEN 1 ELSE 0 END
+         + CASE WHEN net_token_accumulate > 0 THEN 1 ELSE 0 END) AS tokens_score,
+        (CASE WHEN n_other_defi > 1 THEN 1 ELSE 0 END
+         + CASE WHEN n_swap_tx > 1 THEN 1 ELSE 0 END
+         + CASE WHEN n_lp_adds > 0 THEN 1 ELSE 0 END) AS defi_score,
+        (CASE WHEN n_nft_mints > 2 THEN 1 ELSE 0 END
+         + CASE WHEN n_nft_collections > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_nft_trades > 0 THEN 1 ELSE 0 END) AS nfts_score,
+        (CASE WHEN n_stake_tx > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_validators > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_restakes > 0 THEN 1 ELSE 0 END) AS gov_score
+    FROM final_output
+),
+
+total_scores AS (
+    SELECT 
+        {{ dbt_utils.generate_surrogate_key(['user_address', "'ethereum'", "'" ~ current_date_var ~ "'"]) }} AS id,        
+        'ethereum' AS blockchain,
+        '{{ model.config.version }}' AS score_version,
+        user_address,
+        CURRENT_TIMESTAMP AS calculation_time,
+        CAST( '{{ current_date_var }}' AS DATE) AS score_date,
+        activity_score + tokens_score + defi_score + nfts_score + gov_score AS total_score,
+        activity_score,
+        tokens_score,
+        defi_score,
+        nfts_score,
+        gov_score
+    FROM scores
+)
+
+SELECT * FROM total_scores

--- a/models/gold/onchain_scores/onchain_scores__ethereum_v1.sql
+++ b/models/gold/onchain_scores/onchain_scores__ethereum_v1.sql
@@ -354,6 +354,14 @@ total_scores AS (
         nfts_score,
         gov_score
     FROM scores
+    {% if is_incremental() %}        
+        WHERE 
+        {% if current_date_var == modules.datetime.datetime.utcnow().date() %}
+            score_date > (SELECT MAX(score_date) FROM {{ this }})
+        {% else %}
+            score_date = CAST('{{ current_date_var }}' AS DATE)
+        {% endif %}
+    {% endif %}
 )
 
 SELECT * FROM total_scores

--- a/models/gold/onchain_scores/onchain_scores__optimism_v1.sql
+++ b/models/gold/onchain_scores/onchain_scores__optimism_v1.sql
@@ -1,0 +1,385 @@
+{{ config (
+    materialized = "incremental",
+    unique_key = "id",
+    cluster_by = "score_date::date",
+    full_refresh = false,
+    tags = ['gold', 'onchain_scores', 'optimism_scores'],
+    version = 1
+) }}
+
+{% set current_date_query %}
+  SELECT date(sysdate()) as current_date
+{% endset %}
+
+{% set results = run_query(current_date_query) %}
+
+{% if execute %}
+  {% set current_date_var = var('current_date_var', results.columns[0].values()[0]) %}
+{% endif %}
+
+-- set aside centralized exchange addresses for two later cte's
+WITH cex_addresses AS (
+    SELECT ADDRESS, LABEL_TYPE, project_name AS label
+    FROM {{ source('optimism_gold_core','dim_labels')}}
+    WHERE LABEL_TYPE = 'cex'
+),
+
+-- the 3 activity metrics
+activity AS (
+    SELECT
+        from_address AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(DISTINCT CASE WHEN input_data != '0x' THEN to_address END) AS n_contracts,
+        sum(CASE WHEN input_data != '0x' THEN 1 ELSE 0 END) AS n_complex_txn
+    FROM {{ source('optimism_gold_core','fact_transactions') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    GROUP BY from_address, activity_day
+),
+
+-- count transactions from bridges daily
+from_bridge_daily AS (
+    SELECT 
+        receiver AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_bridge_in,
+        COUNT(DISTINCT platform) AS n_contracts
+    FROM {{ source('optimism_gold_defi','ez_bridge_activity') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND receiver NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND receiver NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    GROUP BY receiver, activity_day
+),
+-- tx from bridge
+from_bridge AS (
+SELECT
+user_address,
+sum(n_bridge_in) AS n_bridge_in
+FROM
+from_bridge_daily
+GROUP BY 
+user_address
+),
+
+-- count withdrawals from centralized exchanges daily
+from_cex_daily AS (
+    SELECT 
+        to_address AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_cex_withdrawals
+    FROM {{ source('optimism_gold_core','ez_native_transfers')}} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address IN (SELECT ADDRESS FROM cex_addresses)
+    AND to_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    GROUP BY to_address, activity_day
+    UNION
+    SELECT 
+        TO_ADDRESS AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_cex_withdrawals
+    FROM {{ source('optimism_gold_core','ez_token_transfers') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND FROM_ADDRESS IN (SELECT ADDRESS FROM cex_addresses)
+    AND to_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    GROUP BY TO_ADDRESS, activity_day
+),
+-- total cex
+from_cex AS (
+SELECT
+user_address,
+sum(n_cex_withdrawals) AS n_cex_withdrawals
+FROM
+from_cex_daily
+GROUP BY 
+user_address
+),
+-- count days across the three sources
+combined_days AS (
+    SELECT user_address, activity_day FROM activity
+    UNION
+    SELECT user_address, activity_day FROM from_bridge_daily
+    UNION
+    SELECT user_address, activity_day FROM from_cex_daily
+),
+-- count days across the 3 sources
+user_activity_summary AS (
+    SELECT 
+        user_address,
+        COUNT(DISTINCT activity_day) AS n_days_active
+    FROM combined_days
+    GROUP BY user_address
+),
+-- count txn across the 3 sources
+complex_transactions_and_contracts AS (
+    SELECT 
+        user_address,
+        SUM(n_complex_txn) AS n_complex_txn,
+        SUM(n_contracts) AS n_contracts
+    FROM (
+        SELECT user_address, n_complex_txn, n_contracts FROM activity
+        UNION ALL
+        SELECT user_address, n_bridge_in AS n_complex_txn, n_contracts FROM from_bridge_daily
+        UNION ALL
+        SELECT user_address, 0 AS n_complex_txn, 0 AS n_contracts FROM from_cex_daily
+    ) AS sub
+    GROUP BY user_address
+),
+
+-- net token accumulate
+xfer_in AS (
+    SELECT TO_ADDRESS AS user_address, 
+        COUNT(*) AS n_xfer_in
+    FROM {{ source('optimism_gold_core','ez_token_transfers') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND to_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    GROUP BY TO_ADDRESS
+), 
+
+xfer_out AS (
+    SELECT FROM_ADDRESS AS user_address,
+        COUNT(*) AS n_xfer_out
+    FROM {{ source('optimism_gold_core','ez_token_transfers') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    GROUP BY FROM_ADDRESS
+),
+
+net_token_accumulate AS (
+    SELECT
+        a.user_address,
+        COALESCE((a.n_xfer_in) / (a.n_xfer_in + b.n_xfer_out), 0) AS net_token_accumulate
+    FROM xfer_in a
+    FULL OUTER JOIN xfer_out b ON a.user_address = b.user_address
+),
+-- nfts
+nft_buys AS (
+    SELECT 
+        buyer_address AS user_address, 
+        COUNT(distinct(NFT_ADDRESS)) AS n_nft_collections,
+        COUNT(*) AS n_nft_trades
+    FROM {{ source('optimism_gold_nft','ez_nft_sales') }} 
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND buyer_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND buyer_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    GROUP BY buyer_address
+),
+
+rawmints as (
+select
+*,
+case when topics[0] = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62' then 'erc-1155'
+     when (topics[0] = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' 
+       and topics[3] IS NOT NULL) then 'erc-721'
+     else 'erc-20' end as token_standard
+from {{ source('optimism_gold_core','ez_decoded_event_logs') }} 
+where topics[0] in (
+  '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+  '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
+)
+AND 
+block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+AND decoded_log:from = '0x0000000000000000000000000000000000000000'
+having token_standard IN ('erc-721','erc-1155')
+),
+
+nft_mints AS (
+select 
+decoded_log:to :: string as user_address,
+count(distinct (tx_hash) ) as n_nft_mints
+FROM rawmints
+WHERE
+decoded_log:to NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+AND 
+decoded_log:to NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+group by user_address
+),
+-- governance (just liquid staking on optimism)
+gov_mints AS (
+    SELECT
+        to_address AS user_address,
+        COUNT(distinct(contract_address)) AS n_validators,
+        COUNT(tx_hash) AS n_stake_tx
+    FROM {{ source('optimism_gold_core','ez_token_transfers') }}
+    WHERE 
+        contract_address IN (lower('0x6806411765Af15Bddd26f8f544A34cC40cb9838B'),
+                     lower('0xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2'),
+                     lower('0xE405de8F52ba7559f9df3C368500B6E6ae6Cee49'),
+                     lower('0xc45A479877e1e9Dfe9FcD4056c699575a1045dAA'),
+                     lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb'),
+                     lower('0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8'),
+                     lower('0x513c7E3a9c69cA3e22550eF58AC1C0088e918FFf'))
+    AND BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND to_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    AND to_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND from_address = '0x0000000000000000000000000000000000000000'
+    GROUP BY to_address
+),
+
+gov_restakes AS (
+    SELECT 
+        origin_from_address AS user_address,
+        COUNT(tx_hash) AS n_restakes
+    FROM {{ source('optimism_gold_core','ez_decoded_event_logs') }}
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND contract_address IN (lower('0x6806411765Af15Bddd26f8f544A34cC40cb9838B'),
+                     lower('0xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2'),
+                     lower('0xE405de8F52ba7559f9df3C368500B6E6ae6Cee49'),
+                     lower('0xc45A479877e1e9Dfe9FcD4056c699575a1045dAA'),
+                     lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb'),
+                     lower('0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8'),
+                     lower('0x513c7E3a9c69cA3e22550eF58AC1C0088e918FFf'))
+    AND event_name IN ('Deposit', 'Submitted', 'DepositedFromStaking')
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    GROUP BY origin_from_address
+),
+-- defi
+swaps_in AS (
+    SELECT 
+        origin_from_address AS user_address, 
+        COUNT(*) AS n_swap_tx
+    FROM optimism.defi.ez_dex_swaps
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    GROUP BY origin_from_address
+),
+
+lp_adds AS (
+    SELECT 
+        FROM_ADDRESS AS USER_ADDRESS, 
+        COUNT(*) AS n_lp_adds
+    FROM {{ source('optimism_gold_core','ez_token_transfers') }}
+    WHERE TO_ADDRESS IN (SELECT contract_address FROM optimism.defi.ez_dex_swaps WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90)
+    AND TX_HASH NOT IN (SELECT TX_HASH FROM optimism.defi.ez_dex_swaps WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90)
+    AND FROM_ADDRESS NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    AND FROM_ADDRESS NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    GROUP BY FROM_ADDRESS
+),
+-- list of lp and swap transactions to exclude from other defi below
+lps_swaps AS (
+SELECT 
+tx_hash
+FROM
+{{ source('optimism_gold_core','ez_token_transfers') }}
+WHERE
+to_address IN (SELECT pool_address FROM optimism.defi.dim_dex_liquidity_pools)
+AND
+block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+GROUP BY tx_hash
+),
+-- other defi is a broad category
+other_defi AS (
+    SELECT
+        origin_from_address AS user_address,
+        COUNT(distinct(tx_hash)) AS n_other_defi
+    FROM {{ source('optimism_gold_core','ez_decoded_event_logs') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND contract_address NOT IN (lower('0x6806411765Af15Bddd26f8f544A34cC40cb9838B'),
+                     lower('0xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2'),
+                     lower('0xE405de8F52ba7559f9df3C368500B6E6ae6Cee49'),
+                     lower('0xc45A479877e1e9Dfe9FcD4056c699575a1045dAA'),
+                     lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb'),
+                     lower('0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8'),
+                     lower('0x513c7E3a9c69cA3e22550eF58AC1C0088e918FFf'))
+
+    AND tx_hash NOT IN (SELECT tx_hash FROM lps_swaps)
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_contracts') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('optimism_gold_core','dim_labels')}})
+    AND (
+        lower(event_name) LIKE '%claim%' OR
+        lower(event_name) LIKE '%deposit%' OR
+        lower(event_name) LIKE '%borrow%' OR
+        lower(event_name) LIKE '%lend%' OR
+        lower(event_name) LIKE '%supply%' OR
+        lower(event_name) LIKE '%liquid%' OR
+        lower(event_name) LIKE '%fees%' OR
+        lower(event_name) LIKE '%repay%'
+    )
+    GROUP BY origin_from_address
+),
+-- put it all together!
+final_output AS (
+    SELECT 
+        a.user_address,
+        COALESCE(aa.n_days_active, 0) AS n_days_active,
+        COALESCE(a.n_complex_txn, 0) AS n_complex_txn,
+        COALESCE(a.n_contracts, 0) AS n_contracts,
+        COALESCE(b.n_bridge_in, 0) AS n_bridge_in,
+        COALESCE(c.n_cex_withdrawals, 0) AS n_cex_withdrawals,
+        COALESCE(d.net_token_accumulate, 0) AS net_token_accumulate,
+        COALESCE(e.n_swap_tx, 0) AS n_swap_tx,
+        COALESCE(f.n_other_defi, 0) AS n_other_defi,
+        COALESCE(g.n_lp_adds, 0) AS n_lp_adds,
+        COALESCE(h.n_nft_trades, 0) AS n_nft_trades,
+        COALESCE(h.n_nft_collections, 0) AS n_nft_collections,
+        COALESCE(i.n_nft_mints, 0) AS n_nft_mints,
+        COALESCE(j.n_stake_tx, 0) AS n_stake_tx,
+        COALESCE(j.n_validators, 0) AS n_validators,
+        COALESCE(k.n_restakes, 0) AS n_restakes
+    FROM complex_transactions_and_contracts a
+    LEFT JOIN user_activity_summary aa ON a.user_address = aa.user_address
+    LEFT JOIN from_bridge b ON a.user_address = b.user_address
+    LEFT JOIN from_cex c ON a.user_address = c.user_address
+    LEFT JOIN net_token_accumulate d ON a.user_address = d.user_address
+    LEFT JOIN swaps_in e ON a.user_address = e.user_address
+    LEFT JOIN other_defi f ON a.user_address = f.user_address
+    LEFT JOIN lp_adds g ON a.user_address = g.user_address
+    LEFT JOIN nft_buys h ON a.user_address = h.user_address
+    LEFT JOIN nft_mints i ON a.user_address = i.user_address
+    LEFT JOIN gov_mints j ON a.user_address = j.user_address
+    LEFT JOIN gov_restakes k ON a.user_address = k.user_address
+),
+
+scores AS (
+    SELECT
+        user_address,
+        (CASE WHEN n_days_active > 7 THEN 1 ELSE 0 END
+         + CASE WHEN n_complex_txn > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_contracts > 4 THEN 1 ELSE 0 END) AS activity_score,
+        (CASE WHEN n_bridge_in > 5 THEN 1 ELSE 0 END
+         + CASE WHEN n_cex_withdrawals > 0 THEN 1 ELSE 0 END
+         + CASE WHEN net_token_accumulate > 0 THEN 1 ELSE 0 END) AS tokens_score,
+        (CASE WHEN n_other_defi > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_swap_tx > 7 THEN 1 ELSE 0 END
+         + CASE WHEN n_lp_adds > 4 THEN 1 ELSE 0 END) AS defi_score,
+        (CASE WHEN n_nft_mints > 2 THEN 1 ELSE 0 END
+         + CASE WHEN n_nft_collections > 2 THEN 1 ELSE 0 END
+         + CASE WHEN n_nft_trades > 1 THEN 1 ELSE 0 END) AS nfts_score,
+        (CASE WHEN n_stake_tx > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_validators > 4 THEN 1 ELSE 0 END
+         + CASE WHEN n_restakes > 2 THEN 1 ELSE 0 END) AS gov_score
+    FROM final_output
+),
+
+total_scores AS (
+    SELECT
+        {{ dbt_utils.generate_surrogate_key(['user_address', "'optimism'", "'" ~ current_date_var ~ "'"]) }} AS id,        
+        'optimism' AS blockchain,
+        '{{ model.config.version }}' AS score_version, 
+        user_address,
+        CURRENT_TIMESTAMP AS calculation_time,
+        CAST( '{{ current_date_var }}' AS DATE) AS score_date,
+        activity_score + tokens_score + defi_score + nfts_score + gov_score AS total_score,
+        activity_score,
+        tokens_score,
+        defi_score,
+        nfts_score,
+        gov_score
+    FROM scores
+    {% if is_incremental() %}        
+        WHERE 
+        {% if current_date_var == modules.datetime.datetime.utcnow().date() %}
+            score_date > (SELECT MAX(score_date) FROM {{ this }})
+        {% else %}
+            score_date = CAST('{{ current_date_var }}' AS DATE)
+        {% endif %}
+    {% endif %}
+)
+
+SELECT * FROM total_scores

--- a/models/gold/onchain_scores/onchain_scores__polygon_v1.sql
+++ b/models/gold/onchain_scores/onchain_scores__polygon_v1.sql
@@ -1,0 +1,379 @@
+{{ config (
+    materialized = "incremental",
+    unique_key = "id",
+    cluster_by = "score_date::date",
+    full_refresh = false,
+    tags = ['gold', 'onchain_scores', 'polygon_scores'],
+    version = 1
+) }}
+
+{% set current_date_query %}
+  SELECT date(sysdate()) as current_date
+{% endset %}
+
+{% set results = run_query(current_date_query) %}
+
+{% if execute %}
+  {% set current_date_var = var('current_date_var', results.columns[0].values()[0]) %}
+{% endif %}
+
+-- set aside centralized exchange addresses for two later cte's
+WITH cex_addresses AS (
+    SELECT ADDRESS, LABEL_TYPE, project_name AS label
+    FROM {{ source('polygon_gold_core','dim_labels')}}
+    WHERE LABEL_TYPE = 'cex'
+),
+
+-- the 3 activity metrics
+activity AS (
+    SELECT
+        from_address AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(DISTINCT CASE WHEN input_data != '0x' THEN to_address END) AS n_contracts,
+        sum(CASE WHEN input_data != '0x' THEN 1 ELSE 0 END) AS n_complex_txn
+    FROM {{ source('polygon_gold_core','fact_transactions') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }} )
+    AND from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }} )
+    GROUP BY from_address, activity_day
+),
+
+-- count transactions from bridges daily
+from_bridge_daily AS (
+    SELECT 
+        receiver AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_bridge_in,
+        COUNT(DISTINCT platform) AS n_contracts
+    FROM {{ source('polygon_gold_defi','ez_bridge_activity') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND receiver NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    AND receiver NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    GROUP BY receiver, activity_day
+),
+-- tx from bridge
+from_bridge AS (
+SELECT
+user_address,
+sum(n_bridge_in) AS n_bridge_in
+FROM
+from_bridge_daily
+GROUP BY 
+user_address
+),
+
+-- count withdrawals from centralized exchanges daily
+from_cex_daily AS (
+    SELECT 
+        to_address AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_cex_withdrawals
+    FROM {{ source('polygon_gold_core','ez_native_transfers') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address IN (SELECT ADDRESS FROM cex_addresses)
+    AND to_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    GROUP BY to_address, activity_day
+    UNION
+    SELECT 
+        TO_ADDRESS AS user_address,
+        DATE(block_timestamp) AS activity_day,
+        COUNT(*) AS n_cex_withdrawals
+    FROM {{ source('polygon_gold_core','ez_token_transfers') }} 
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND FROM_ADDRESS IN (SELECT ADDRESS FROM cex_addresses)
+    AND to_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    GROUP BY TO_ADDRESS, activity_day
+),
+-- total cex
+from_cex AS (
+SELECT
+user_address,
+sum(n_cex_withdrawals) AS n_cex_withdrawals
+FROM
+from_cex_daily
+GROUP BY 
+user_address
+),
+-- count days across the three sources
+combined_days AS (
+    SELECT user_address, activity_day FROM activity
+    UNION
+    SELECT user_address, activity_day FROM from_bridge_daily
+    UNION
+    SELECT user_address, activity_day FROM from_cex_daily
+),
+-- count days across the 3 sources
+user_activity_summary AS (
+    SELECT 
+        user_address,
+        COUNT(DISTINCT activity_day) AS n_days_active
+    FROM combined_days
+    GROUP BY user_address
+),
+-- count txn across the 3 sources
+complex_transactions_and_contracts AS (
+    SELECT 
+        user_address,
+        SUM(n_complex_txn) AS n_complex_txn,
+        SUM(n_contracts) AS n_contracts
+    FROM (
+        SELECT user_address, n_complex_txn, n_contracts FROM activity
+        UNION ALL
+        SELECT user_address, n_bridge_in AS n_complex_txn, n_contracts FROM from_bridge_daily
+        UNION ALL
+        SELECT user_address, 0 AS n_complex_txn, 0 AS n_contracts FROM from_cex_daily
+    ) AS sub
+    GROUP BY user_address
+),
+
+-- net token accumulate
+xfer_in AS (
+    SELECT TO_ADDRESS AS user_address, 
+        COUNT(*) AS n_xfer_in
+    FROM {{ source('polygon_gold_core','ez_token_transfers') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND to_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    GROUP BY TO_ADDRESS
+), 
+
+xfer_out AS (
+    SELECT FROM_ADDRESS AS user_address,
+        COUNT(*) AS n_xfer_out
+    FROM {{ source('polygon_gold_core','ez_token_transfers') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    AND from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    GROUP BY FROM_ADDRESS
+),
+
+net_token_accumulate AS (
+    SELECT
+        a.user_address,
+        COALESCE((a.n_xfer_in) / (a.n_xfer_in + b.n_xfer_out), 0) AS net_token_accumulate
+    FROM xfer_in a
+    FULL OUTER JOIN xfer_out b ON a.user_address = b.user_address
+),
+-- nfts
+nft_buys AS (
+    SELECT 
+        buyer_address AS user_address, 
+        COUNT(distinct(NFT_ADDRESS)) AS n_nft_collections,
+        COUNT(*) AS n_nft_trades
+    FROM {{ source('polygon_gold_nft','ez_nft_sales') }} 
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND buyer_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    AND buyer_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    GROUP BY buyer_address
+),
+
+rawmints as (
+select
+*,
+case when topics[0] = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62' then 'erc-1155'
+     when (topics[0] = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' 
+       and topics[3] IS NOT NULL) then 'erc-721'
+     else 'erc-20' end as token_standard
+from {{ source('polygon_gold_core','ez_decoded_event_logs') }} 
+where topics[0] in (
+  '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+  '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'
+)
+AND 
+block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+AND decoded_log:from = '0x0000000000000000000000000000000000000000'
+having token_standard IN ('erc-721','erc-1155')
+),
+
+nft_mints AS (
+select 
+decoded_log:to :: string as user_address,
+count(distinct (tx_hash) ) as n_nft_mints
+FROM rawmints
+WHERE
+decoded_log:to NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+AND 
+decoded_log:to NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+group by user_address
+),
+-- governance (just liquid staking on polygon)
+gov_mints AS (
+    SELECT
+        to_address AS user_address,
+        COUNT(distinct(contract_address)) AS n_validators,
+        COUNT(tx_hash) AS n_stake_tx
+    FROM {{ source('polygon_gold_core','ez_token_transfers') }}
+    WHERE 
+        contract_address IN (lower('0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4'),
+                     lower('0xa3Fa99A148fA48D14Ed51d610c367C61876997F1'),
+                     lower('0x2acD702F7D35d3D2915663d7f7CbDF2863Ec6E79'),
+                     lower('0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6'),
+                     lower('0x0E9b89007eEE9c958c0EDA24eF70723C2C93dD58'))
+    AND BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND to_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    AND to_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    AND from_address = '0x0000000000000000000000000000000000000000'
+    GROUP BY to_address
+),
+
+gov_restakes AS (
+    SELECT 
+        origin_from_address AS user_address,
+        COUNT(tx_hash) AS n_restakes
+    FROM {{ source('polygon_gold_core','ez_decoded_event_logs') }}
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND contract_address IN (lower('0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4'),
+                     lower('0xa3Fa99A148fA48D14Ed51d610c367C61876997F1'),
+                     lower('0x2acD702F7D35d3D2915663d7f7CbDF2863Ec6E79'),
+                     lower('0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6'),
+                     lower('0x0E9b89007eEE9c958c0EDA24eF70723C2C93dD58'))
+    AND event_name IN ('Deposit', 'Submitted', 'DepositedFromStaking')
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    GROUP BY origin_from_address
+),
+-- defi
+swaps_in AS (
+    SELECT 
+        origin_from_address AS user_address, 
+        COUNT(*) AS n_swap_tx
+    FROM polygon.defi.ez_dex_swaps
+    WHERE BLOCK_TIMESTAMP >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    GROUP BY origin_from_address
+),
+
+lp_adds AS (
+    SELECT 
+        FROM_ADDRESS AS USER_ADDRESS, 
+        COUNT(*) AS n_lp_adds
+    FROM {{ source('polygon_gold_core','ez_token_transfers') }}
+    WHERE TO_ADDRESS IN (SELECT contract_address FROM polygon.defi.ez_dex_swaps WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90)
+    AND TX_HASH NOT IN (SELECT TX_HASH FROM polygon.defi.ez_dex_swaps WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90)
+    AND FROM_ADDRESS NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    AND FROM_ADDRESS NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    GROUP BY FROM_ADDRESS
+),
+-- list of lp and swap transactions to exclude from other defi below
+lps_swaps AS (
+SELECT 
+tx_hash
+FROM
+{{ source('polygon_gold_core','ez_token_transfers') }}
+WHERE
+to_address IN (SELECT pool_address FROM polygon.defi.dim_dex_liquidity_pools)
+AND
+block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+GROUP BY tx_hash
+),
+-- other defi is a broad category
+other_defi AS (
+    SELECT
+        origin_from_address AS user_address,
+        COUNT(distinct(tx_hash)) AS n_other_defi
+    FROM {{ source('polygon_gold_core','ez_decoded_event_logs') }}
+    WHERE block_timestamp >= CAST( '{{ current_date_var }}' AS DATE) - 90
+    AND contract_address NOT IN (lower('0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4'),
+                     lower('0xa3Fa99A148fA48D14Ed51d610c367C61876997F1'),
+                     lower('0x2acD702F7D35d3D2915663d7f7CbDF2863Ec6E79'),
+                     lower('0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6'),
+                     lower('0x0E9b89007eEE9c958c0EDA24eF70723C2C93dD58'))
+
+    AND tx_hash NOT IN (SELECT tx_hash FROM lps_swaps)
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_contracts') }})
+    AND origin_from_address NOT IN (SELECT address FROM {{ source('polygon_gold_core','dim_labels') }})
+    AND (
+        lower(event_name) LIKE '%claim%' OR
+        lower(event_name) LIKE '%deposit%' OR
+        lower(event_name) LIKE '%borrow%' OR
+        lower(event_name) LIKE '%lend%' OR
+        lower(event_name) LIKE '%supply%' OR
+        lower(event_name) LIKE '%liquid%' OR
+        lower(event_name) LIKE '%fees%' OR
+        lower(event_name) LIKE '%repay%'
+    )
+    GROUP BY origin_from_address
+),
+-- put it all together!
+final_output AS (
+    SELECT 
+        a.user_address,
+        COALESCE(aa.n_days_active, 0) AS n_days_active,
+        COALESCE(a.n_complex_txn, 0) AS n_complex_txn,
+        COALESCE(a.n_contracts, 0) AS n_contracts,
+        COALESCE(b.n_bridge_in, 0) AS n_bridge_in,
+        COALESCE(c.n_cex_withdrawals, 0) AS n_cex_withdrawals,
+        COALESCE(d.net_token_accumulate, 0) AS net_token_accumulate,
+        COALESCE(e.n_swap_tx, 0) AS n_swap_tx,
+        COALESCE(f.n_other_defi, 0) AS n_other_defi,
+        COALESCE(g.n_lp_adds, 0) AS n_lp_adds,
+        COALESCE(h.n_nft_trades, 0) AS n_nft_trades,
+        COALESCE(h.n_nft_collections, 0) AS n_nft_collections,
+        COALESCE(i.n_nft_mints, 0) AS n_nft_mints,
+        COALESCE(j.n_stake_tx, 0) AS n_stake_tx,
+        COALESCE(j.n_validators, 0) AS n_validators,
+        COALESCE(k.n_restakes, 0) AS n_restakes
+    FROM complex_transactions_and_contracts a
+    LEFT JOIN user_activity_summary aa ON a.user_address = aa.user_address
+    LEFT JOIN from_bridge b ON a.user_address = b.user_address
+    LEFT JOIN from_cex c ON a.user_address = c.user_address
+    LEFT JOIN net_token_accumulate d ON a.user_address = d.user_address
+    LEFT JOIN swaps_in e ON a.user_address = e.user_address
+    LEFT JOIN other_defi f ON a.user_address = f.user_address
+    LEFT JOIN lp_adds g ON a.user_address = g.user_address
+    LEFT JOIN nft_buys h ON a.user_address = h.user_address
+    LEFT JOIN nft_mints i ON a.user_address = i.user_address
+    LEFT JOIN gov_mints j ON a.user_address = j.user_address
+    LEFT JOIN gov_restakes k ON a.user_address = k.user_address
+),
+
+scores AS (
+    SELECT
+        user_address,
+        (CASE WHEN n_days_active > 4 THEN 1 ELSE 0 END
+         + CASE WHEN n_complex_txn > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_contracts > 3 THEN 1 ELSE 0 END) AS activity_score,
+        (CASE WHEN n_bridge_in > 2 THEN 1 ELSE 0 END
+         + CASE WHEN n_cex_withdrawals > 1 THEN 1 ELSE 0 END
+         + CASE WHEN net_token_accumulate > 0 THEN 1 ELSE 0 END) AS tokens_score,
+        (CASE WHEN n_other_defi > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_swap_tx > 3 THEN 1 ELSE 0 END
+         + CASE WHEN n_lp_adds > 1 THEN 1 ELSE 0 END) AS defi_score,
+        (CASE WHEN n_nft_mints > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_nft_collections > 2 THEN 1 ELSE 0 END
+         + CASE WHEN n_nft_trades > 2 THEN 1 ELSE 0 END) AS nfts_score,
+        (CASE WHEN n_stake_tx > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_validators > 0 THEN 1 ELSE 0 END
+         + CASE WHEN n_restakes > 0 THEN 1 ELSE 0 END) AS gov_score
+    FROM final_output
+),
+
+total_scores AS (
+    SELECT
+        {{ dbt_utils.generate_surrogate_key(['user_address', "'polygon'", "'" ~ current_date_var ~ "'"]) }} AS id,        
+        'polygon' AS blockchain,
+        '{{ model.config.version }}' AS score_version, 
+        user_address,
+        CURRENT_TIMESTAMP AS calculation_time,
+        CAST( '{{ current_date_var }}' AS DATE) AS score_date,
+        activity_score + tokens_score + defi_score + nfts_score + gov_score AS total_score,
+        activity_score,
+        tokens_score,
+        defi_score,
+        nfts_score,
+        gov_score
+    FROM scores
+    {% if is_incremental() %}        
+        WHERE 
+        {% if current_date_var == modules.datetime.datetime.utcnow().date() %}
+            score_date > (SELECT MAX(score_date) FROM {{ this }})
+        {% else %}
+            score_date = CAST('{{ current_date_var }}' AS DATE)
+        {% endif %}
+    {% endif %}
+)
+
+SELECT * FROM total_scores

--- a/models/gold/onchain_scores/onchain_scores_avalanche_properties.yml
+++ b/models/gold/onchain_scores/onchain_scores_avalanche_properties.yml
@@ -1,0 +1,18 @@
+version: 2
+
+# https://docs.getdbt.com/reference/model-properties
+
+models:
+  - name: onchain_scores__avalanche
+    description: Onchain scores for Avalanche user addresses 
+    latest_version: 1
+
+    columns:
+      - name: id 
+        description: MD5 of blockchain, user_address & score_date
+        
+    versions:
+      - v: 1 
+        defined_in: onchain_scores__avalanche_v1
+        description: Initial version of the model
+      

--- a/models/gold/onchain_scores/onchain_scores_base_properties.yml
+++ b/models/gold/onchain_scores/onchain_scores_base_properties.yml
@@ -1,0 +1,20 @@
+version: 2
+
+# https://docs.getdbt.com/reference/model-properties
+
+models:
+  - name: onchain_scores__base
+    description: Onchain scores for Base user addresses 
+    latest_version: 1
+
+    columns:
+      - name: id 
+        description: MD5 of blockchain, user_address & score_date
+        
+    versions:
+      - v: 1 
+        defined_in: onchain_scores__base_v1
+        description: Initial version of the model
+        config:
+          alias: base
+      

--- a/models/gold/onchain_scores/onchain_scores_ethereum_properties.yml
+++ b/models/gold/onchain_scores/onchain_scores_ethereum_properties.yml
@@ -1,0 +1,20 @@
+version: 2
+
+# https://docs.getdbt.com/reference/model-properties
+
+models:
+  - name: onchain_scores__ethereum
+    description: Onchain scores for Ethereum user addresses 
+    latest_version: 1
+
+    columns:
+      - name: id 
+        description: MD5 of blockchain, user_address & score_date
+        
+    versions:
+      - v: 1 
+        defined_in: onchain_scores__ethereum_v1
+        description: Initial version of the model
+        config:
+          alias: ethereum
+      

--- a/models/gold/onchain_scores/onchain_scores_optimism_properties.yml
+++ b/models/gold/onchain_scores/onchain_scores_optimism_properties.yml
@@ -1,0 +1,18 @@
+version: 2
+
+# https://docs.getdbt.com/reference/model-properties
+
+models:
+  - name: onchain_scores__polygon
+    description: Onchain scores for polygon user addresses 
+    latest_version: 1
+
+    columns:
+      - name: id 
+        description: MD5 of blockchain, user_address & score_date
+        
+    versions:
+      - v: 1 
+        defined_in: onchain_scores__polygon_v1
+        description: Initial version of the model
+      

--- a/models/gold/onchain_scores/onchain_scores_polygon_properties.yml
+++ b/models/gold/onchain_scores/onchain_scores_polygon_properties.yml
@@ -1,0 +1,18 @@
+version: 2
+
+# https://docs.getdbt.com/reference/model-properties
+
+models:
+  - name: onchain_scores__polygon
+    description: Onchain scores for polygon user addresses 
+    latest_version: 1
+
+    columns:
+      - name: id 
+        description: MD5 of blockchain, user_address & score_date
+        
+    versions:
+      - v: 1 
+        defined_in: onchain_scores__polygon_v1
+        description: Initial version of the model
+      

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -90,5 +90,47 @@ sources:
     schema: nft
     tables:
       - name: ez_nft_sales
-
-
+  - name: polygon_gold_core
+    database: "{{ 'polygon' if target.database == 'datascience' else 'polygon_dev' }}"
+    schema: core
+    tables:
+      - name: dim_labels
+      - name: dim_contracts
+      - name: fact_transactions
+      - name: ez_native_transfers
+      - name: ez_decoded_event_logs
+      - name: ez_token_transfers
+  - name: polygon_gold_defi
+    database: "{{ 'polygon' if target.database == 'datascience' else 'polygon_dev' }}"
+    schema: defi
+    tables:
+      - name: ez_bridge_activity
+      - name: ez_dex_swaps
+      - name: dim_dex_liquidity_pools
+  - name: polygon_gold_nft
+    database: "{{ 'polygon' if target.database == 'datascience' else 'polygon_dev' }}"
+    schema: nft
+    tables:
+      - name: ez_nft_sales
+  - name: optimism_gold_core
+    database: "{{ 'optimism' if target.database == 'datascience' else 'optimism_dev' }}"
+    schema: core
+    tables:
+      - name: dim_labels
+      - name: dim_contracts
+      - name: fact_transactions
+      - name: ez_native_transfers
+      - name: ez_token_transfers
+      - name: ez_decoded_event_logs
+  - name: optimism_gold_defi
+    database: "{{ 'optimism' if target.database == 'datascience' else 'optimism_dev' }}"
+    schema: defi
+    tables:
+      - name: ez_bridge_activity
+      - name: ez_dex_swaps
+      - name: dim_dex_liquidity_pools
+  - name: optimism_gold_nft
+    database: "{{ 'optimism' if target.database == 'datascience' else 'optimism_dev' }}"
+    schema: nft
+    tables:
+      - name: ez_nft_sales

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -46,5 +46,49 @@ sources:
     schema: nft
     tables:
       - name: ez_nft_sales
+  - name: ethereum_gold_core
+    database: "{{ 'ethereum' if target.database == 'datascience' else 'ethereum_dev' }}"
+    schema: core
+    tables:
+      - name: dim_labels
+      - name: dim_contracts
+      - name: fact_transactions
+      - name: ez_native_transfers
+      - name: ez_token_transfers
+      - name: ez_decoded_event_logs
+  - name: ethereum_gold_defi
+    database: "{{ 'ethereum' if target.database == 'datascience' else 'ethereum_dev' }}"
+    schema: defi
+    tables:
+      - name: ez_bridge_activity
+      - name: ez_dex_swaps
+      - name: dim_dex_liquidity_pools
+  - name: ethereum_gold_nft
+    database: "{{ 'ethereum' if target.database == 'datascience' else 'ethereum_dev' }}"
+    schema: nft
+    tables:
+      - name: ez_nft_sales
+  - name: base_gold_core
+    database: "{{ 'base' if target.database == 'datascience' else 'base_dev' }}"
+    schema: core
+    tables:
+      - name: dim_labels
+      - name: dim_contracts
+      - name: fact_transactions
+      - name: ez_native_transfers
+      - name: ez_token_transfers
+      - name: ez_decoded_event_logs
+  - name: base_gold_defi
+    database: "{{ 'base' if target.database == 'datascience' else 'base_dev' }}"
+    schema: defi
+    tables:
+      - name: ez_bridge_activity
+      - name: ez_dex_swaps
+      - name: dim_dex_liquidity_pools
+  - name: base_gold_nft
+    database: "{{ 'base' if target.database == 'datascience' else 'base_dev' }}"
+    schema: nft
+    tables:
+      - name: ez_nft_sales
 
 


### PR DESCRIPTION
- Ports [polygon_scores](https://github.com/FlipsideCrypto/data_science/blob/master/analysis/ar_scores/sql/polygon_scores.sql) & [optimism_scores](https://github.com/FlipsideCrypto/data_science/blob/master/analysis/ar_scores/sql/optimism_scores.sql) as incremental dbt models
  - Adds jinja interpolated sources for CTE's to `ethereum & base` `core/defi/nft` tables
  - Adds dbt model versioning config
  - Adds incremental logic to account for dynamic `current_date` < `sysdate` adhoc runs  